### PR TITLE
Fixes up typos and grammar on the getting-started page

### DIFF
--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -13,8 +13,8 @@ faith and try the functions out, I have no doubt you'll find yourself falling in
 
 ### Featured Functions
 
-Come, dip you're toe in the water. Here's a few functions we can't live without anymore.
-Hopefuly you'll find them useful as well.
+Come, dip your toe in the water. Here are a few functions we can't live without anymore.
+Hopefully, you'll find them useful as well.
 
 #### try
 The `_.try` function abstracts the logical fork of a try/catch and provides an _error
@@ -42,9 +42,9 @@ for (const i of range(10, 20, 2)) {
 ```
 
 #### select
-The `_.select` function takes a mapper and filter function and runs them together for you, in
-a single iteration. No more writing a reduce because you need to map and filter and you don't
-want to implement them seperatly for performance sake.
+The `_.select` function takes a mapper and filter function and runs them together for you in
+a single iteration. No more writing a reduce because you need to map and filter, and you don't
+want to implement them separately for performance's sake.
 
 ```ts
 const superPoweredGodsFromEgypt = _.select(
@@ -55,8 +55,8 @@ const superPoweredGodsFromEgypt = _.select(
 ```
 
 #### defer
-The `_.defer` function let's register functions to run as cleanup while running an async function. It's 
-like a try/finally but you can register the finally block at specific times.
+The `_.defer` function lets register functions to run as cleanup while running an async function. It's 
+like a try/finally, but you can register the finally block at specific times.
 
 ```ts
 await _.defer(async (defer) => {
@@ -75,7 +75,7 @@ await _.defer(async (defer) => {
 ```
 
 #### objectify
-The `_.objectify` function help you convert a list to an object in one step. Typically, we either do this
+The `_.objectify` function helps you convert a list to an object in one step. Typically, we either do this
 in two steps or write a reduce.
 
 ```ts
@@ -86,20 +86,20 @@ const godsByCulture = _.objectify(gods, g => g.name, g => g.culture)
 
 ### Lodash
 
-Lodash was incredible. In a time when Javascript was still maturing it provided the power to things you couldn't
+Lodash was incredible. When Javascript was still maturing, it provided the power to things you couldn't
 easily do in the vanilla. That was last decade. In this decade, the needs are different. The goal with Radash
 is to provide the powerful functions you need, not the ones the runtimes now provide, and to do it with great types
-and source code thats easy to read and understand.
+and source code that's easy to read and understand.
 
 #### Saying No
 
 Radash does not provide `_.map` or `_.filter` functions. They were helpful before optional chaining and nullish coalescing.
 Now, there really isn't a need.  
 
-In the last 10 years, the javascript community as a whole, and the Typescript community specifically, has moved
+In the last ten years, the javascript community as a whole, and the Typescript community specifically, has moved
 closer to some key values: **deterministic is good, polymorphic is bad, strong types are everything**. A part of Lodash's
-charm was that it let you pass different types to a function and get different behavior based on the type. An example of that
-is the `_.map` function which can take a collection or an object and will map over either. Radash doesn't provide that
+charm was that it let you pass different types to a function and get other behavior based on the type. An example 
+is the `_.map` function, which can take a collection or an object and map over either. Radash doesn't provide that
 kind of polymorphic behavior.  
 
-Sorry not sorry.
+Sorry, not sorry.

--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -86,7 +86,7 @@ const godsByCulture = _.objectify(gods, g => g.name, g => g.culture)
 
 ### Lodash
 
-Lodash was incredible. When Javascript was still maturing, it provided the power to things you couldn't
+Lodash was incredible. When JavaScript was still maturing, it provided the power to things you couldn't
 easily do in the vanilla. That was last decade. In this decade, the needs are different. The goal with Radash
 is to provide the powerful functions you need, not the ones the runtimes now provide, and to do it with great types
 and source code that's easy to read and understand.
@@ -96,7 +96,7 @@ and source code that's easy to read and understand.
 Radash does not provide `_.map` or `_.filter` functions. They were helpful before optional chaining and nullish coalescing.
 Now, there really isn't a need.  
 
-In the last ten years, the javascript community as a whole, and the Typescript community specifically, has moved
+In the last ten years, the JavaScript community as a whole, and the Typescript community specifically, has moved
 closer to some key values: **deterministic is good, polymorphic is bad, strong types are everything**. A part of Lodash's
 charm was that it let you pass different types to a function and get other behavior based on the type. An example 
 is the `_.map` function, which can take a collection or an object and map over either. Radash doesn't provide that

--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -55,7 +55,7 @@ const superPoweredGodsFromEgypt = _.select(
 ```
 
 #### defer
-The `_.defer` function lets register functions to run as cleanup while running an async function. It's 
+The `_.defer` function lets you register functions to run as cleanup while running an async function. It's 
 like a try/finally, but you can register the finally block at specific times.
 
 ```ts


### PR DESCRIPTION
Ran the page content for the `/docs/getting-started` page through Grammarly to fix up some typos and grammar