### PR TITLE
camal -> camel

### DIFF
--- a/src/pages/docs/string-camal.mdx
+++ b/src/pages/docs/string-camal.mdx
@@ -1,6 +1,6 @@
 ---
-title: camal
-description: Convert a string to camal case
+title: camel
+description: Convert a string to camel case
 ---
 
 import { SourceLinkAndPreview } from '@/components/SourceLinkAndPreview'
@@ -8,7 +8,7 @@ import { TestingLinkAndPreview } from '@/components/TestingLinkAndPreview'
 
 ## Basic usage
 
-Given a string returns it in camal case format.
+Given a string returns it in camel case format.
 
 ```ts
 import { camal } from 'radash'


### PR DESCRIPTION
Should not it be 'camel' instead of 'camal'?
Then need to rename referenced functions as well...