### PR TITLE
fix: typo in code examples

### DIFF
--- a/src/pages/docs/curry-chain.mdx
+++ b/src/pages/docs/curry-chain.mdx
@@ -17,7 +17,7 @@ const genesis = () => 0
 const addFive = (num: number) => num + 5
 const twoX = (num: number) => num * 2
 
-const chained = _.chain(
+const chained = chain(
   genesis,
   addFive,
   twoX

--- a/src/pages/docs/curry-memo.mdx
+++ b/src/pages/docs/curry-memo.mdx
@@ -13,7 +13,7 @@ Wrap a function with memo to get a function back that automagically returns valu
 ```ts
 import { memo } from 'radash'
 
-const timestamp = _.memo(() => Date.now())
+const timestamp = memo(() => Date.now())
 
 const now = timestamp()
 const later = timestamp()
@@ -28,7 +28,7 @@ You can optionally pass a `ttl` (time to live) that will expire memoized results
 ```ts
 import { memo, sleep } from 'radash'
 
-const timestamp = _.memo(() => Date.now(), {
+const timestamp = memo(() => Date.now(), {
   ttl: 1000 // milliseconds
 })
 
@@ -48,7 +48,7 @@ now === muchLater // => false
 You can optionally customize how values are stored when memoized.
 
 ```ts
-const timestamp = _.memo(({ group }: { group: string }) => {
+const timestamp = memo(({ group }: { group: string }) => {
   const ts = Date.now()
   return `${ts}::${group}`
 }, {

--- a/src/pages/docs/series-series.mdx
+++ b/src/pages/docs/series-series.mdx
@@ -15,7 +15,7 @@ import { series } from 'radash'
 
 type Weekday = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
 
-const weekdays = _.series<Weekday>(
+const weekdays = series<Weekday>(
   'monday',
   'tuesday',
   'wednesday',


### PR DESCRIPTION
Fix undefined reference to `_.` in code examples.