### PR TITLE
Update object-pick.mdx

### DIFF
--- a/src/pages/docs/object-pick.mdx
+++ b/src/pages/docs/object-pick.mdx
@@ -20,7 +20,7 @@ const fish = {
   barckish: false
 }
 
-pick(fish, ['name', 'source]) // => { name, source }
+pick(fish, ['name', 'source']) // => { name, source }
 ```
 
 ## Testing


### PR DESCRIPTION
Missing close quote in the given example 
```
pick(fish, ['name', 'source]) // => { name, source }
```
Results in error will trying to test this code