### PR TITLE
fix: output in `max` & `min` example

### DIFF
--- a/src/pages/docs/array-max.mdx
+++ b/src/pages/docs/array-max.mdx
@@ -27,7 +27,7 @@ const fish = [{
   source: 'lake'
 }]
 
-max(fish, f => f.weight) // => marlin
+max(fish, f => f.weight) // => {name: "Marlin", weight: 105, source: "ocean"}
 ```
 
 ## Testing

--- a/src/pages/docs/array-min.mdx
+++ b/src/pages/docs/array-min.mdx
@@ -27,7 +27,7 @@ const fish = [{
   source: 'lake'
 }]
 
-min(fish, f => f.weight) // => bass
+min(fish, f => f.weight) // => {name: "Bass", weight: 8, source: "lake"}
 ```
 
 ## Testing


### PR DESCRIPTION
- In `max` document changed output from `marlin` to `{name: "Marlin", weight: 105, source: "ocean"}`
- In `min` document changed output from `bass` to `{name: "Bass", weight: 8, source: "lake"}`