### PR TITLE
Fix typo of `camel` function

### DIFF
--- a/src/pages/docs/string-camal.mdx
+++ b/src/pages/docs/string-camal.mdx
@@ -1,6 +1,6 @@
 ---
 title: camal
-description: Convert a string to camal case
+description: Convert a string to camel case
 ---
 
 import { SourceLinkAndPreview } from '@/components/SourceLinkAndPreview'
@@ -8,18 +8,18 @@ import { TestingLinkAndPreview } from '@/components/TestingLinkAndPreview'
 
 ## Basic usage
 
-Given a string returns it in camal case format.
+Given a string returns it in camel case format.
 
 ```ts
-import { camal } from 'radash'
+import { camel } from 'radash'
 
 camal('green fish blue fish') // => greenFishBlueFish
 ```
 
 ## Testing
 
-<TestingLinkAndPreview module="string" func="camal" />
+<TestingLinkAndPreview module="string" func="camel" />
 
 ## Source
 
-<SourceLinkAndPreview module="string" func="camal" />
+<SourceLinkAndPreview module="string" func="camel" />


### PR DESCRIPTION
It seems that the docs had a typo in writing `camal` instead of `camel`.
https://github.com/rayepps/radash/blob/master/src/string.ts#L13 shows that the function is called `camel`.