### PR TITLE
Fix: type in async-sleep.mdx

### DIFF
--- a/src/pages/docs/async-sleep.mdx
+++ b/src/pages/docs/async-sleep.mdx
@@ -8,7 +8,7 @@ import { TestingLinkAndPreview } from '@/components/TestingLinkAndPreview'
 
 ## Basic usage
 
-The `_.sleep` functino allows you to delay in milliseconds.
+The `_.sleep` function allows you to delay in milliseconds.
 
 ```ts
 import { sleep } from 'radash'


### PR DESCRIPTION
Fixed typo for word `function` on line 11