### PR TITLE
Camal -> Camel typo in the docs

### DIFF
--- a/src/pages/docs/string-camal.mdx
+++ b/src/pages/docs/string-camal.mdx
@@ -1,6 +1,6 @@
 ---
-title: camal
-description: Convert a string to camal case
+title: camel
+description: Convert a string to camel case
 ---
 
 import { SourceLinkAndPreview } from '@/components/SourceLinkAndPreview'
@@ -8,18 +8,18 @@ import { TestingLinkAndPreview } from '@/components/TestingLinkAndPreview'
 
 ## Basic usage
 
-Given a string returns it in camal case format.
+Given a string returns it in camel case format.
 
 ```ts
-import { camal } from 'radash'
+import { camel } from 'radash'
 
-camal('green fish blue fish') // => greenFishBlueFish
+camel('green fish blue fish') // => greenFishBlueFish
 ```
 
 ## Testing
 
-<TestingLinkAndPreview module="string" func="camal" />
+<TestingLinkAndPreview module="string" func="camel" />
 
 ## Source
 
-<SourceLinkAndPreview module="string" func="camal" />
+<SourceLinkAndPreview module="string" func="camel" />


### PR DESCRIPTION
The API has been updated a while back but there's still a typo in the docs.

The two elements (TestingLinkAndPreview and SourceLinkAndPreview) have both have a "func" attribute with the value "camal" that I also changed but it should probably be tested that it works.