### PR TITLE
Fix typo on the function name

### DIFF
--- a/src/pages/docs/string-camal.mdx
+++ b/src/pages/docs/string-camal.mdx
@@ -11,15 +11,15 @@ import { TestingLinkAndPreview } from '@/components/TestingLinkAndPreview'
 Given a string returns it in camel case format.
 
 ```ts
-import { camal } from 'radash'
+import { camel } from 'radash'
 
 camal('green fish blue fish') // => greenFishBlueFish
 ```
 
 ## Testing
 
-<TestingLinkAndPreview module="string" func="camal" />
+<TestingLinkAndPreview module="string" func="camel" />
 
 ## Source
 
-<SourceLinkAndPreview module="string" func="camal" />
+<SourceLinkAndPreview module="string" func="camel" />


### PR DESCRIPTION
As `radash` causes a breaking change changing the name of the function `camal` to `camel`, the docs had to be updated.